### PR TITLE
Use genuine MBS (generic .picture) art style

### DIFF
--- a/dist/entity-image.user.js
+++ b/dist/entity-image.user.js
@@ -183,26 +183,11 @@
 
 	                const a = document.createElement("a");
 	                a.href = imageUrls[0].title;
+	                a.className = "picture";
 	                div.appendChild(a);
 	                
 	                const img = document.createElement("img");
 	                img.src = imageUrls[0].url;
-	                img.style.width = "218px";
-	                switch(extractEntityFromURL(document.location.href).type){
-	                case 'artist':
-	                case 'place':
-	                    img.style.height = "218px";
-	                    img.style.objectFit = "cover";
-	                    break;
-	                case 'label':
-	                    img.style.height = "218px";
-	                    img.style.objectFit = "contain";
-	                    break;
-	                case 'event':
-	                    img.style.minHeight = "218px";
-	                    img.style.objectFit = "contain";
-	                    break;
-	                }
 	                a.appendChild(img);
 
 	                if(imageUrls.length > 1){

--- a/src/userscripts/entity-image.user.js
+++ b/src/userscripts/entity-image.user.js
@@ -50,26 +50,11 @@ function runUserscript(){
 
                 const a = document.createElement("a");
                 a.href = imageUrls[0].title;
+                a.className = "picture";
                 div.appendChild(a);
                 
                 const img = document.createElement("img");
                 img.src = imageUrls[0].url;
-                img.style.width = "218px";
-                switch(extractEntityFromURL(document.location.href).type){
-                case 'artist':
-                case 'place':
-                    img.style.height = "218px";
-                    img.style.objectFit = "cover";
-                    break;
-                case 'label':
-                    img.style.height = "218px";
-                    img.style.objectFit = "contain";
-                    break;
-                case 'event':
-                    img.style.minHeight = "218px";
-                    img.style.objectFit = "contain";
-                    break;
-                }
                 a.appendChild(img);
 
                 if(imageUrls.length > 1){


### PR DESCRIPTION
This commit makes use of the genuine MBS style for all kinds of arts:

```css
#sidebar .cover-art img, #sidebar .event-art img, #sidebar .picture img {
    max-height: 300px;
    max-width: 218px;
}
```

Instead of redefining many per-entity-type styles
that are cropped or too small in some cases

- Cropped https://musicbrainz.org/artist/b9545342-1e6d-4dae-84ac-013374ad8d7c
- Cropped https://musicbrainz.org/artist/462a85b4-83ac-4164-86b3-e5ac6a7ec040

Fixes:

- #13

---

@zabe40, may I leave you manage the version number, OK?
(In my memory, [auto-updating may not work](https://github.com/jesus2099/konami-command/pull/1#issuecomment-366431040) with versions like `2024-03-30`, they should rather be like `2024.3.30`)
