### PR TITLE
Drop event support

### DIFF
--- a/dist/entity-image.user.js
+++ b/dist/entity-image.user.js
@@ -3,7 +3,7 @@
 // @version       2024-03-30
 // @namespace     https://github.com/zabe40
 // @author        zabe
-// @description   Display images on Musicbrainz for artists, labels, places, and events
+// @description   Display images on Musicbrainz for artists, labels, and places
 // @homepageURL   https://github.com/zabe40/musicbrainz-userscripts#musicbrainz-entity-images
 // @downloadURL   https://raw.github.com/zabe40/musicbrainz-userscripts/main/dist/entity-image.user.js
 // @updateURL     https://raw.github.com/zabe40/musicbrainz-userscripts/main/dist/entity-image.user.js
@@ -12,11 +12,9 @@
 // @match         *://*.musicbrainz.org/artist/*
 // @match         *://*.musicbrainz.org/label/*
 // @match         *://*.musicbrainz.org/place/*
-// @match         *://*.musicbrainz.org/event/*
 // @match         *://*.musicbrainz.eu/artist/*
 // @match         *://*.musicbrainz.eu/label/*
 // @match         *://*.musicbrainz.eu/place/*
-// @match         *://*.musicbrainz.eu/event/*
 // ==/UserScript==
 
 (function () {
@@ -196,10 +194,6 @@
 	                    break;
 	                case 'label':
 	                    img.style.height = "218px";
-	                    img.style.objectFit = "contain";
-	                    break;
-	                case 'event':
-	                    img.style.minHeight = "218px";
 	                    img.style.objectFit = "contain";
 	                    break;
 	                }

--- a/src/userscripts/entity-image.meta.js
+++ b/src/userscripts/entity-image.meta.js
@@ -4,9 +4,9 @@ const metadata = {
     name: 'MusicBrainz Entity Images',
     namespace: 'https://github.com/zabe40',
     version: '2024-03-30',
-    description: 'Display images on Musicbrainz for artists, labels, places, and events',
+    description: 'Display images on Musicbrainz for artists, labels, and places',
     author: 'zabe',
-    match: cartesian(['*://*.musicbrainz.',['org','eu'],'/',['artist', 'label', 'place', 'event'],'/*'])
+    match: cartesian(['*://*.musicbrainz.',['org','eu'],'/',['artist', 'label', 'place'],'/*'])
         .map((array)=>{return array.join("");}),
     grant: 'GM_xmlhttpRequest'
 };

--- a/src/userscripts/entity-image.user.js
+++ b/src/userscripts/entity-image.user.js
@@ -65,10 +65,6 @@ function runUserscript(){
                     img.style.height = "218px";
                     img.style.objectFit = "contain";
                     break;
-                case 'event':
-                    img.style.minHeight = "218px";
-                    img.style.objectFit = "contain";
-                    break;
                 }
                 a.appendChild(img);
 


### PR DESCRIPTION
Now it is handleded genuinely by MBS

Fixes:

- #15

---

@zabe40, may I leave you manage the version number, OK?
(In my memory, [auto-updating may not work](https://github.com/jesus2099/konami-command/pull/1#issuecomment-366431040) with versions like `2024-03-30`, they should rather be like `2024.3.30`)
