### PR TITLE
Fixing Mobile; Update youtube-link-canonicalizer.user.js

### DIFF
--- a/dist/bandcamp-tag-importer.user.js
+++ b/dist/bandcamp-tag-importer.user.js
@@ -17,7 +17,7 @@
 (function () {
     'use strict';
 
-    function fetchURL(url, options){
+    function fetchURL(url, options = {}){
         return new Promise((resolve, reject) => {
             GM_xmlhttpRequest({
                 url: url,

--- a/dist/entity-image.user.js
+++ b/dist/entity-image.user.js
@@ -104,7 +104,7 @@
 		}
 	}
 
-	function fetchURL(url, options){
+	function fetchURL(url, options = {}){
 	    return new Promise((resolve, reject) => {
 	        GM_xmlhttpRequest({
 	            url: url,

--- a/dist/taggregator.user.js
+++ b/dist/taggregator.user.js
@@ -25,7 +25,7 @@
   var img = "data:image/svg+xml,%3csvg version='1.1' x='0px' y='0px' viewBox='0 0 100 75.289574' xml:space='preserve' width='100' height='75.289574' xmlns='http://www.w3.org/2000/svg' xmlns:svg='http://www.w3.org/2000/svg'%3e %3cpolygon points='44%2c69.5 75.9%2c37.6 68.8%2c30.5 44%2c55.3 31.2%2c42.6 24.1%2c49.6 ' transform='matrix(1.9305019%2c0%2c0%2c1.9305019%2c-46.525096%2c-58.880308)' /%3e%3c/svg%3e";
     var successIcon = img;
 
-  function fetchURL(url, options){
+  function fetchURL(url, options = {}){
       return new Promise((resolve, reject) => {
           GM_xmlhttpRequest({
               url: url,

--- a/dist/youtube-link-canonicalizer.user.js
+++ b/dist/youtube-link-canonicalizer.user.js
@@ -153,10 +153,6 @@
 	    return new Promise((resolve, reject) => {
 	        GM_xmlhttpRequest({
 	            url: url,
-                headers: {
-                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-                    ...(options.headers || {})
-                },
 	            onload: function(response){
 	                if(400 <= response.status){
 	                    reject(new Error(`HTTP error! Status: ${response.status}`,
@@ -242,23 +238,24 @@
 	}
 
 	function getCanonicalizedYoutubeLink(link){
-	    return fetchURL(link).then((response) => {
-	        const html = response.responseText;
-	        const parser = new DOMParser();
-	        let doc = parser.parseFromString(html, "text/html");
-            const canonicalLink = doc.querySelector("link[rel=\"canonical\"]");
-            
-            if (!canonicalLink) {
-                // Fallback to other methods if canonical link not found
-                const ogUrlMeta = doc.querySelector("meta[property=\"og:url\"]");
-                if (ogUrlMeta && ogUrlMeta.content) {
-                    return ogUrlMeta.content;
-                }
-                
-                throw new Error("Cannot find canonical YouTube URL in the response");
-            }
-            
-	        return canonicalLink.href;
+	    return fetchURL(link, {headers: {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+	                                     + "AppleWebKit/537.36 (KHTML, like Gecko) "
+	                                     + "Chrome/91.0.4472.124 "
+	                                     + "Safari/537.36"}})
+	        .then((response) => {
+	            const html = response.responseText;
+	            const parser = new DOMParser();
+	            let doc = parser.parseFromString(html, "text/html");
+	            const canonicalLink = doc.querySelector("link[rel=\"canonical\"]");
+	            if (canonicalLink) {
+	                return canonicalLink.href;
+	            }
+	            // Fallback to other methods if canonical link not found
+	            const ogUrlMeta = doc.querySelector("meta[property=\"og:url\"]");
+	            if (ogUrlMeta && ogUrlMeta.content) {
+	                return ogUrlMeta.content;
+	            }
+	            throw new Error("Cannot find canonical YouTube URL in the response");
 	    });
 	}
 

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,4 +1,4 @@
-export function fetchURL(url, options){
+export function fetchURL(url, options = {}){
     return new Promise((resolve, reject) => {
         GM_xmlhttpRequest({
             url: url,

--- a/src/userscripts/youtube-link-canonicalizer.meta.js
+++ b/src/userscripts/youtube-link-canonicalizer.meta.js
@@ -3,7 +3,7 @@ import { cartesian} from '@agarimo/cartesian';
 const metadata = {
     name: 'MusicBrainz Youtube Link Canonicalizer',
     namespace: 'https://github.com/zabe40',
-    version: '2024.8.12',
+    version: '2025.4.16',
     description: 'Correct youtube @username artist links to channel IDs',
     author: 'zabe',
     match: cartesian(["*://*.musicbrainz.",["org","eu"],"/",

--- a/src/userscripts/youtube-link-canonicalizer.user.js
+++ b/src/userscripts/youtube-link-canonicalizer.user.js
@@ -64,11 +64,24 @@ function isCanonicalYoutubeLink(link){
 }
 
 function getCanonicalizedYoutubeLink(link){
-    return fetchURL(link).then((response) => {
-        const html = response.responseText;
-        const parser = new DOMParser();
-        let doc = parser.parseFromString(html, "text/html");
-        return doc.querySelector("link[rel=\"canonical\"]").href;
+    return fetchURL(link, {headers: {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                                     + "AppleWebKit/537.36 (KHTML, like Gecko) "
+                                     + "Chrome/91.0.4472.124 "
+                                     + "Safari/537.36"}})
+        .then((response) => {
+            const html = response.responseText;
+            const parser = new DOMParser();
+            let doc = parser.parseFromString(html, "text/html");
+            const canonicalLink = doc.querySelector("link[rel=\"canonical\"]");
+            if (canonicalLink) {
+                return canonicalLink.href;
+            }
+            // Fallback to other methods if canonical link not found
+            const ogUrlMeta = doc.querySelector("meta[property=\"og:url\"]");
+            if (ogUrlMeta && ogUrlMeta.content) {
+                return ogUrlMeta.content;
+            }
+            throw new Error("Cannot find canonical YouTube URL in the response");
     });
 }
 


### PR DESCRIPTION
A fix for mobile browsers where the script wasn't working properly. YouTube serves different HTML on mobile that doesn't include the canonical link in the expected format. By adding a desktop browser User-Agent to the requests, we trick YouTube into serving the desktop version of the page with the proper canonical link element. Also added a fallback to check for the og:url meta tag as a backup, which makes the script more robust against future YouTube changes.